### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# [Deprecated] This repository is no longer maintained.
+Issue reports and pull requests will not be attended.
+
 # identity-outbound-auth-push
 
 


### PR DESCRIPTION
This is to add a deprecation notice to the readme file of the repository since we no longer maintain this repository as a push notification based authentication connector.